### PR TITLE
the property for credentials is wrong

### DIFF
--- a/powerbi-docs/developer/migrate-code-snippets.md
+++ b/powerbi-docs/developer/migrate-code-snippets.md
@@ -149,7 +149,7 @@ En este fragmento de código, estamos utilizando las credenciales sin cifrar par
     }
 
     var basicCreds = new BasicCreds() { user = <sqldb_username>, pwd = <sqldb_password> };
-    var body = new SetCredsRequestBody() { credentialType = "Basic", basicCreds = basicCreds };
+    var body = new SetCredsRequestBody() { credentialType = "Basic", basicCredentials = basicCreds };
 
     var url = string.Format("https://api.powerbi.com/v1.0/myorg/gateways/{0}/datasources/{1}", <gateway_id>, <datasource_id>);
     var request = new HttpRequestMessage(new HttpMethod("PATCH"), url);


### PR DESCRIPTION
{"error":{"code":"BadRequest","message":"Bad Request","details":[{"message":"The property 'basicCreds' does not exist on type 'Microsoft.PowerBI.ServiceContracts.Api.GatewayDatasource'. Make sure to only use property names that are defined by the type.","target":"datasourceDelta"}]}}

To fix it the property has to be renamed to basicCredentials